### PR TITLE
update --query information

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It has colourful output, understands normal command-line argument syntax, suppor
 ### Query options
 
     <arguments>              Human-readable host names, nameservers, types, or classes
-    -q, --query=HOST         Host name or IP address to query
+    -q, --query=HOST         Host name or domain name to query
     -t, --type=TYPE          Type of the DNS record being queried (A, MX, NS...)
     -n, --nameserver=ADDR    Address of the nameserver to send packets to
     --class=CLASS            Network class of the DNS record being queried (IN, CH, HS)

--- a/completions/dog.fish
+++ b/completions/dog.fish
@@ -4,7 +4,7 @@ complete -c dog -s '?' -l 'help'    -d "Show list of command-line options"
 
 # Query options
 complete -c dog -x -a "(__fish_print_hostnames) A AAAA CAA CNAME HINFO MX NS PTR SOA SRV TXT IN CH HS"
-complete -c dog -s 'q' -l 'query'      -d "Host name or IP address to query" -x -a "(__fish_print_hostnames)"
+complete -c dog -s 'q' -l 'query'      -d "Host name or domain name to query" -x -a "(__fish_print_hostnames)"
 complete -c dog -s 't' -l 'type'       -d "Type of the DNS record being queried" -x -a "A AAAA CAA CNAME HINFO MX NS PTR SOA SRV TXT"
 complete -c dog -s 'n' -l 'nameserver' -d "Address of the nameserver to send packets to" -x -a "(__fish_print_hostnames)"
 complete -c dog        -l 'class'      -d "Network class of the DNS record being queried" -x -a "IN CH HS"

--- a/completions/dog.zsh
+++ b/completions/dog.zsh
@@ -4,7 +4,7 @@ __dog() {
     _arguments \
         "(- 1 *)"{-v,--version}"[Show version of dog]" \
         "(- 1 *)"{-\?,--help}"[Show list of command-line options]" \
-        {-q,--query}"[Host name or IP address to query]::_hosts" \
+        {-q,--query}"[Host name or domain name to query]::_hosts" \
         {-t,--type}"[Type of the DNS record being queried]:(record type):(A AAAA CAA CNAME HINFO MX NS PTR SOA SRV TXT)" \
         {-n,--nameserver}"[Address of the nameserver to send packets to]::_hosts;" \
         --class"[Network class of the DNS record being queried]:(network class):(IN CH HS)" \

--- a/src/options.rs
+++ b/src/options.rs
@@ -46,7 +46,7 @@ impl Options {
         let mut opts = getopts::Options::new();
 
         // Query options
-        opts.optmulti("q", "query",       "Host name or IP address to query", "HOST");
+        opts.optmulti("q", "query",       "Host name or domain name to query", "HOST");
         opts.optmulti("t", "type",        "Type of the DNS record being queried (A, MX, NS...)", "TYPE");
         opts.optmulti("n", "nameserver",  "Address of the nameserver to send packets to", "ADDR");
         opts.optmulti("",  "class",       "Network class of the DNS record being queried (IN, CH, HS)", "CLASS");

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -10,7 +10,7 @@
 
 \4mQuery options:\0m
   \32m<arguments>\0m              Human-readable host names, nameservers, types, or classes
-  \1;33m-q\0m, \1;33m--query\0m=\33mHOST\0m         Host name or IP address to query
+  \1;33m-q\0m, \1;33m--query\0m=\33mHOST\0m         Host name or domain name to query
   \1;33m-t\0m, \1;33m--type\0m=\33mTYPE\0m          Type of the DNS record being queried (A, MX, NS...)
   \1;33m-n\0m, \1;33m--nameserver\0m=\33mADDR\0m    Address of the nameserver to send packets to
   \1;33m--class\0m=\33mCLASS\0m            Network class of the DNS record being queried (IN, CH, HS)


### PR DESCRIPTION
In #32, I recommended to update `--query` information as I found it misleading.  Currently, querying for IP addresses does not work.  Instead of just mentioning it, I figured I would make a pull request.  All mentions of `--query` now match the man page. 