### PR TITLE
Add CLI option to increase output verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It has colourful output, understands normal command-line argument syntax, suppor
     --color, --colour=WHEN   When to colourise the output (always, automatic, never)
     --seconds                Do not format durations, display them as seconds
     --time                   Print how long the response took to arrive
+    -v                       Increase output verbosity by adding multiple (-vv)
 
 
 ---

--- a/completions/dog.bash
+++ b/completions/dog.bash
@@ -4,7 +4,7 @@ _dog()
     prev=${COMP_WORDS[COMP_CWORD-1]}
 
     case "$prev" in
-        -'?'|--help|-v|--version)
+        -'?'|--help|-v|-V|--version)
             return
             ;;
 

--- a/completions/dog.fish
+++ b/completions/dog.fish
@@ -1,5 +1,5 @@
 # Meta options
-complete -c dog -s 'v' -l 'version' -d "Show version of dog"
+complete -c dog -s 'V' -l 'version' -d "Show version of dog"
 complete -c dog -s '?' -l 'help'    -d "Show list of command-line options"
 
 # Query options
@@ -44,3 +44,4 @@ complete -c dog        -l 'colour'     -d "When to colourise the output" -x -a "
 "
 complete -c dog        -l 'seconds'    -d "Do not format durations, display them as seconds"
 complete -c dog        -l 'time'       -d "Print how long the response took to arrive"
+complete -c dog -s 'v'                 -d "Increase verbosity by adding multiple -v options"

--- a/completions/dog.zsh
+++ b/completions/dog.zsh
@@ -2,7 +2,7 @@
 
 __dog() {
     _arguments \
-        "(- 1 *)"{-v,--version}"[Show version of dog]" \
+        "(- 1 *)"{-V,--version}"[Show version of dog]" \
         "(- 1 *)"{-\?,--help}"[Show list of command-line options]" \
         {-q,--query}"[Host name or domain name to query]::_hosts" \
         {-t,--type}"[Type of the DNS record being queried]:(record type):(A AAAA CAA CNAME HINFO MX NS PTR SOA SRV TXT)" \
@@ -20,6 +20,7 @@ __dog() {
         {--color,--colour}"[When to use terminal colours]:(setting):(always automatic never)" \
         --seconds"[Do not format durations, display them as seconds]" \
         --time"[Print how long the response took to arrive"] \
+        -v"[Increase verbosity by adding multiple -v options]" \
         '*:filename:_hosts'
 }
 

--- a/man/dog.1.md
+++ b/man/dog.1.md
@@ -118,6 +118,9 @@ OUTPUT OPTIONS
 `--time`
 : Print how long the response took to arrive.
 
+`-v`
+: Increase logging verbosity by adding multiple '`-vv`'. This will override the '`DOG_DEBUG`' environment variable.
+
 
 META OPTIONS
 ============

--- a/src/usage.txt
+++ b/src/usage.txt
@@ -35,4 +35,5 @@
 
 \4mMeta options:\0m
   \1;33m-?\0m, \1;33m--help\0m               Print list of command-line options
-  \1;33m-v\0m, \1;33m--version\0m            Print version information
+  \1;33m-V\0m, \1;33m--version\0m            Print version information
+  \1;33m-v\0m                       Increase verbosity by adding multiple (-vv)


### PR DESCRIPTION
This change will add a CLI option `-v` to increase output verbosity which can be used as an alternative to providing the `DOG_DEBUG` environment variable. You can specify one or more flags to increase the logging level:

Eg.
```
dog -v google.com    # Debug level
dog -vv google.com   # Trace level
```

The previous short flag for version was moved to `-V` leaving the long flag `--version` as-is.

The usage looks like this:
```
  -V, --version            Print version information
  -v                       Increase verbosity by adding multiple (-vv)
```

The cli arguments will override the `DOG_DEBUG` environment variable.