### PR TITLE
Fix segfault if no resolver was detected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "log",
  "mutagen",
  "pretty_assertions",
+ "thiserror",
 ]
 
 [[package]]
@@ -162,6 +163,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
+ "thiserror",
 ]
 
 [[package]]
@@ -651,6 +653,26 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/dns-transport/Cargo.toml
+++ b/dns-transport/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 
 [dependencies]
 
+# error handling
+thiserror = "1.0.22"
+
 # dns wire protocol
 dns = { path = "../dns" }
 

--- a/dns-transport/src/error.rs
+++ b/dns-transport/src/error.rs
@@ -1,68 +1,62 @@
 /// Something that can go wrong making a DNS request.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
 
     /// The data in the response did not parse correctly from the DNS wire
     /// protocol format.
-    WireError(dns::WireError),
+    #[error("{0:#}")]
+    WireError(#[from] dns::WireError),
+
+    /// No dns resolvers could be detected on the system.
+    #[error("No nameserver found")]
+    NoNameservers,
 
     /// There was a problem with the network making a TCP or UDP request.
-    NetworkError(std::io::Error),
+    #[error("{0:#}")]
+    NetworkError(#[from] std::io::Error),
 
     /// Not enough information was received from the server before a `read`
     /// call returned zero bytes.
+    #[error("Truncated response")]
     TruncatedResponse,
 
     /// There was a problem making a TLS request.
     #[cfg(feature="tls")]
-    TlsError(native_tls::Error),
+    #[error("{0:#}")]
+    TlsError(#[from] native_tls::Error),
 
     /// There was a problem _establishing_ a TLS request.
     #[cfg(feature="tls")]
-    TlsHandshakeError(native_tls::HandshakeError<std::net::TcpStream>),
+    #[error("{0:#}")]
+    TlsHandshakeError(#[from] native_tls::HandshakeError<std::net::TcpStream>),
 
     /// There was a problem decoding the response HTTP headers or body.
     #[cfg(feature="https")]
-    HttpError(httparse::Error),
+    #[error("{0:#}")]
+    HttpError(#[from] httparse::Error),
 
     /// The HTTP response code was something other than 200 OK, along with the
     /// response code text, if present.
     #[cfg(feature="https")]
+    #[error("Nameserver returned HTTP {0} ({1:?})")]
     WrongHttpStatus(u16, Option<String>),
 }
 
-
-// From impls
-
-impl From<dns::WireError> for Error {
-    fn from(inner: dns::WireError) -> Self {
-        Self::WireError(inner)
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(inner: std::io::Error) -> Self {
-        Self::NetworkError(inner)
-    }
-}
-
-#[cfg(feature="tls")]
-impl From<native_tls::Error> for Error {
-    fn from(inner: native_tls::Error) -> Self {
-        Self::TlsError(inner)
-    }
-}
-
-#[cfg(feature="tls")]
-impl From<native_tls::HandshakeError<std::net::TcpStream>> for Error {
-    fn from(inner: native_tls::HandshakeError<std::net::TcpStream>) -> Self {
-        Self::TlsHandshakeError(inner)
-    }
-}
-
-#[cfg(feature="https")]
-impl From<httparse::Error> for Error {
-    fn from(inner: httparse::Error) -> Self {
-        Self::HttpError(inner)
+impl Error {
+    /// Returns the “phase” of operation where an error occurred. This gets shown
+    /// to the user so they can debug what went wrong.
+    pub fn erroneous_phase(&self) -> &'static str {
+        match self {
+            Error::WireError(_)          => "protocol",
+            Error::NoNameservers         => "system",
+            Error::TruncatedResponse     |
+            Error::NetworkError(_)       => "network",
+            #[cfg(feature="tls")]
+            Error::TlsError(_)           |
+            Error::TlsHandshakeError(_)  => "tls",
+            #[cfg(feature="https")]
+            Error::HttpError(_)          |
+            Error::WrongHttpStatus(_,_)  => "http",
+        }
     }
 }

--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 
 [dependencies]
+# error handling
+thiserror = "1.0.22"
 
 # logging
 log = "0.4"

--- a/dns/src/record/a.rs
+++ b/dns/src/record/a.rs
@@ -27,7 +27,7 @@ impl Wire for A {
         if stated_length != 4 {
             warn!("Length is incorrect (record length {:?}, but should be four)", stated_length);
             let mandated_length = MandatedLength::Exactly(4);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let mut buf = [0_u8; 4];
@@ -63,7 +63,7 @@ mod test {
         ];
 
         assert_eq!(A::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 3, mandated_length: MandatedLength::Exactly(4) }));
+                   Err(WireError::wrong_record_length(3, MandatedLength::Exactly(4))));
     }
 
     #[test]
@@ -74,13 +74,13 @@ mod test {
         ];
 
         assert_eq!(A::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 5, mandated_length: MandatedLength::Exactly(4) }));
+                   Err(WireError::wrong_record_length(5, MandatedLength::Exactly(4))));
     }
 
     #[test]
     fn record_empty() {
         assert_eq!(A::read(0, &mut Cursor::new(&[])),
-                   Err(WireError::WrongRecordLength { stated_length: 0, mandated_length: MandatedLength::Exactly(4) }));
+                   Err(WireError::wrong_record_length(0, MandatedLength::Exactly(4))));
     }
 
     #[test]

--- a/dns/src/record/aaaa.rs
+++ b/dns/src/record/aaaa.rs
@@ -27,7 +27,7 @@ impl Wire for AAAA {
         if stated_length != 16 {
             warn!("Length is incorrect (stated length {:?}, but should be sixteen)", stated_length);
             let mandated_length = MandatedLength::Exactly(16);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let mut buf = [0_u8; 16];
@@ -66,7 +66,7 @@ mod test {
         ];
 
         assert_eq!(AAAA::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 17, mandated_length: MandatedLength::Exactly(16) }));
+                   Err(WireError::wrong_record_length(17, MandatedLength::Exactly(16))));
     }
 
     #[test]
@@ -76,13 +76,13 @@ mod test {
         ];
 
         assert_eq!(AAAA::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 5, mandated_length: MandatedLength::Exactly(16) }));
+                   Err(WireError::wrong_record_length(5, MandatedLength::Exactly(16))));
     }
 
     #[test]
     fn record_empty() {
         assert_eq!(AAAA::read(0, &mut Cursor::new(&[])),
-                   Err(WireError::WrongRecordLength { stated_length: 0, mandated_length: MandatedLength::Exactly(16) }));
+                   Err(WireError::wrong_record_length(0, MandatedLength::Exactly(16))));
     }
 
     #[test]

--- a/dns/src/record/eui48.rs
+++ b/dns/src/record/eui48.rs
@@ -25,7 +25,7 @@ impl Wire for EUI48 {
         if stated_length != 6 {
             warn!("Length is incorrect (record length {:?}, but should be six)", stated_length);
             let mandated_length = MandatedLength::Exactly(6);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let mut octets = [0_u8; 6];
@@ -69,7 +69,7 @@ mod test {
         ];
 
         assert_eq!(EUI48::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 3, mandated_length: MandatedLength::Exactly(6) }));
+                   Err(WireError::wrong_record_length(3, MandatedLength::Exactly(6))));
     }
 
     #[test]
@@ -80,13 +80,13 @@ mod test {
         ];
 
         assert_eq!(EUI48::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 7, mandated_length: MandatedLength::Exactly(6) }));
+                   Err(WireError::wrong_record_length(7, MandatedLength::Exactly(6))));
     }
 
     #[test]
     fn record_empty() {
         assert_eq!(EUI48::read(0, &mut Cursor::new(&[])),
-                   Err(WireError::WrongRecordLength { stated_length: 0, mandated_length: MandatedLength::Exactly(6) }));
+                   Err(WireError::wrong_record_length(0, MandatedLength::Exactly(6))));
     }
 
     #[test]

--- a/dns/src/record/eui64.rs
+++ b/dns/src/record/eui64.rs
@@ -25,7 +25,7 @@ impl Wire for EUI64 {
         if stated_length != 8 {
             warn!("Length is incorrect (record length {:?}, but should be eight)", stated_length);
             let mandated_length = MandatedLength::Exactly(8);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let mut octets = [0_u8; 8];
@@ -69,7 +69,7 @@ mod test {
         ];
 
         assert_eq!(EUI64::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 3, mandated_length: MandatedLength::Exactly(8) }));
+                   Err(WireError::wrong_record_length(3, MandatedLength::Exactly(8))));
     }
 
     #[test]
@@ -80,13 +80,13 @@ mod test {
         ];
 
         assert_eq!(EUI64::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 9, mandated_length: MandatedLength::Exactly(8) }));
+                   Err(WireError::wrong_record_length(9, MandatedLength::Exactly(8))));
     }
 
     #[test]
     fn record_empty() {
         assert_eq!(EUI64::read(0, &mut Cursor::new(&[])),
-                   Err(WireError::WrongRecordLength { stated_length: 0, mandated_length: MandatedLength::Exactly(8) }));
+                   Err(WireError::wrong_record_length(0, MandatedLength::Exactly(8))));
     }
 
     #[test]

--- a/dns/src/record/loc.rs
+++ b/dns/src/record/loc.rs
@@ -92,7 +92,7 @@ impl Wire for LOC {
 
         if stated_length != 16 {
             let mandated_length = MandatedLength::Exactly(16);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let size_bits = c.read_u8()?;
@@ -273,7 +273,7 @@ mod test {
         ];
 
         assert_eq!(LOC::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 2, mandated_length: MandatedLength::Exactly(16) }));
+                   Err(WireError::wrong_record_length(2, MandatedLength::Exactly(16))));
     }
 
     #[test]
@@ -290,7 +290,7 @@ mod test {
         ];
 
         assert_eq!(LOC::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 19, mandated_length: MandatedLength::Exactly(16) }));
+                   Err(WireError::wrong_record_length(19, MandatedLength::Exactly(16))));
     }
 
     #[test]

--- a/dns/src/record/openpgpkey.rs
+++ b/dns/src/record/openpgpkey.rs
@@ -22,7 +22,7 @@ impl Wire for OPENPGPKEY {
     fn read(stated_length: u16, c: &mut Cursor<&[u8]>) -> Result<Self, WireError> {
         if stated_length == 0 {
             let mandated_length = MandatedLength::AtLeast(1);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let mut key = vec![0_u8; usize::from(stated_length)];
@@ -72,7 +72,7 @@ mod test {
     #[test]
     fn record_empty() {
         assert_eq!(OPENPGPKEY::read(0, &mut Cursor::new(&[])),
-                   Err(WireError::WrongRecordLength { stated_length: 0, mandated_length: MandatedLength::AtLeast(1) }));
+                   Err(WireError::wrong_record_length(0, MandatedLength::AtLeast(1))));
     }
 
     #[test]

--- a/dns/src/record/sshfp.rs
+++ b/dns/src/record/sshfp.rs
@@ -40,7 +40,7 @@ impl Wire for SSHFP {
 
         if stated_length <= 2 {
             let mandated_length = MandatedLength::AtLeast(3);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let fingerprint_length = stated_length - 1 - 1;
@@ -108,7 +108,7 @@ mod test {
         ];
 
         assert_eq!(SSHFP::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 2, mandated_length: MandatedLength::AtLeast(3) }));
+                   Err(WireError::wrong_record_length(2, MandatedLength::AtLeast(3))));
     }
 
     #[test]

--- a/dns/src/record/tlsa.rs
+++ b/dns/src/record/tlsa.rs
@@ -48,7 +48,7 @@ impl Wire for TLSA {
 
         if stated_length <= 3 {
             let mandated_length = MandatedLength::AtLeast(4);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let certificate_data_length = stated_length - 1 - 1 - 1;
@@ -121,7 +121,7 @@ mod test {
         ];
 
         assert_eq!(TLSA::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 3, mandated_length: MandatedLength::AtLeast(4) }));
+                   Err(WireError::wrong_record_length(3, MandatedLength::AtLeast(4))));
     }
 
     #[test]

--- a/dns/src/record/uri.rs
+++ b/dns/src/record/uri.rs
@@ -43,7 +43,7 @@ impl Wire for URI {
         // The target must not be empty.
         if stated_length <= 4 {
             let mandated_length = MandatedLength::AtLeast(5);
-            return Err(WireError::WrongRecordLength { stated_length, mandated_length });
+            return Err(WireError::wrong_record_length(stated_length, mandated_length));
         }
 
         let remaining_length = stated_length - 4;
@@ -107,7 +107,7 @@ mod test {
         ];
 
         assert_eq!(URI::read(buf.len() as _, &mut Cursor::new(buf)),
-                   Err(WireError::WrongRecordLength { stated_length: 4, mandated_length: MandatedLength::AtLeast(5) }));
+                   Err(WireError::wrong_record_length(4, MandatedLength::AtLeast(5))));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,16 @@ fn run(Options { requests, format, measure_time }: Options) -> i32 {
     let timer = if measure_time { Some(Instant::now()) } else { None };
 
     let mut errored = false;
-    for (request, transport) in requests.generate() {
+
+    let requests = match requests.generate() {
+        Ok(requests) => requests,
+        Err(e) => {
+            format.print_error(e);
+            return exits::OPTIONS_ERROR;
+        },
+    };
+
+    for (request, transport) in requests {
         let result = transport.send(&request);
 
         match result {


### PR DESCRIPTION
This slightly refactors error handling to remove some `.expect()` calls that cause segfaults due to `panic = "abort"`.

## Setup
```
% cat /etc/resolv.conf
# Generated by resolvconf
search lan
nameserver fe80::1337:ff:1337:1337%enp0s25
```

## Before
```
% dog google.com
thread 'main' panicked at 'No nameserver found', src/requests.rs:88:86
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[1]    2814256 abort (core dumped)  dog google.com
```

## After
```
% cargo run -- google.com
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/dog google.com`
Error [system]: No nameserver found
```