### PR TITLE
Note nix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ To install dog, you can download a pre-compiled binary, or you can compile it fr
 
 - For Arch Linux, install the [`dog`](https://www.archlinux.org/packages/community/x86_64/dog/) package.
 - For Homebrew on macOS, install the [`dog`](https://formulae.brew.sh/formula/dog) formula.
+- For Nix on Linux or MacOS, install the `nixpkgs.dogdns` package (nixpkgs 21.05 and newer).
 
 
 ### Downloads


### PR DESCRIPTION
See
https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&query=dogdns.
It will be in the upcoming 21.05 release as it is currently in unstable.