### PR TITLE
Add NO_COLOR env support

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::time::Duration;
+use std::env;
 
 use dns::{Response, Query, Answer, QClass, ErrorCode, WireError, MandatedLength};
 use dns::record::{Record, RecordType, UnknownQtype, OPT};
@@ -55,7 +56,7 @@ impl UseColours {
     /// overridden the colour setting, and if not, whether output is to a
     /// terminal.
     pub fn should_use_colours(self) -> bool {
-        self == Self::Always || (atty::is(atty::Stream::Stdout) && self != Self::Never)
+        self == Self::Always || (atty::is(atty::Stream::Stdout) && env::var("NO_COLOR").is_err() && self != Self::Never)
     }
 
     /// Creates a palette of colours depending on the user’s wishes or whether


### PR DESCRIPTION
This allows the program to not output colours when using the `NO_COLOR` environmental variable. For example when running `NO_COLOR=1 dog github.com`. To read more about this environmental variable take a look at https://no-color.org/