### PR TITLE
Allow _ in domain names

### DIFF
--- a/dns/src/strings.rs
+++ b/dns/src/strings.rs
@@ -22,7 +22,7 @@ pub struct Labels {
 
 #[cfg(feature = "with_idna")]
 fn label_to_ascii(label: &str) -> Result<String, unic_idna::Errors> {
-    let flags = unic_idna::Flags{use_std3_ascii_rules: true, transitional_processing: false, verify_dns_length: true};
+    let flags = unic_idna::Flags{use_std3_ascii_rules: false, transitional_processing: false, verify_dns_length: true};
     unic_idna::to_ascii(label, flags)
 }
 


### PR DESCRIPTION
While using dog locally to check some specific DKIM records, I realised that the `_` was not recognised as a valid character in a  domain name.

```sh
$ dog default._domainkey.barrobes.com TXT
dog: Invalid options: Invalid domain "default._domainkey.barrobes.com"
```

After the change:

```sh
$ cargo run -q default._domainkey.barrobes.com TXT
TXT default._domainkey.barrobes.com. 1h53m30s   "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwOHVlAPSLPIbBSuXThuNq+d4OXI9A3Gln10RRN1c5ZIyrXkPReqAuBVp+/IFXHJdyCXPCmF/aAfs1Iiu3oXzVSPIOZIpVEfEIBazs2RHvnWFCJWom+O6tbWRmKAyacVZQfEhrdA8LPzCjSEXRs4wUClyQuOvDU1qOik5CAbsTYcL60eahdId+xiZFlDfrFf/OIdsR/diX91ur3hUBbO4H7Iue3DXBqgmAIvmi57DibqTbwOz+UXF7Bqoxe0pFlljQi18UV9Ck7mASq7qDAmMqQwqMJ24XPvKCiw2KLBWOrSqBXzzBinZTS/9WlkDFXcBH1ewyIpWixQeXcZjq7oMQwIDAQAB;"
```

It still works with IDNA domains:

```
$ cargo run -q österreich.icom.museum
CNAME xn--sterreich-z7a.icom.museum. 9m29s   "redirections.icom.museum."
    A redirections.icom.museum.      9m29s   81.201.190.55
$ cargo run -q беларусь.icom.museum
CNAME xn--80abmy0agn7e.icom.museum. 10m00s   "redirections.icom.museum."
    A redirections.icom.museum.      9m59s   81.201.190.55
```

Possibly this fix is not the right/full solution, but it's a way to keep the ball rolling. I didn't want to have a separate build of dog disabling IDNA just for this purpose (that might have done it). I think it should be possible to support IDNA and still allow for underscores.

Open to any suggestions, and happy to add tests.