### PR TITLE
Add TLS ALPN support

### DIFF
--- a/dns-transport/Cargo.toml
+++ b/dns-transport/Cargo.toml
@@ -18,12 +18,12 @@ dns = { path = "../dns" }
 log = "0.4"
 
 # tls networking
-native-tls = { version = "0.2", optional = true }
+native-tls = { version = "0.2.8", optional = true }
 
 # http response parsing
 httparse = { version = "1.3", optional = true }
 
 [features]
 default = []  # these are enabled in the main dog crate
-with_tls   = ["native-tls"]
-with_https = ["native-tls", "httparse"]
+with_tls   = ["native-tls", "native-tls/alpn"]
+with_https = ["native-tls", "native-tls/alpn", "httparse"]

--- a/dns-transport/src/https.rs
+++ b/dns-transport/src/https.rs
@@ -35,7 +35,9 @@ impl Transport for HttpsTransport {
 
     #[cfg(feature = "with_https")]
     fn send(&self, request: &Request) -> Result<Response, Error> {
-        let connector = native_tls::TlsConnector::new()?;
+        let mut builder = native_tls::TlsConnector::builder();
+        builder.request_alpns(&["http/1.1"]);
+        let connector = builder.build()?;
 
         let (domain, path) = self.split_domain().expect("Invalid HTTPS nameserver");
 

--- a/dns-transport/src/tls.rs
+++ b/dns-transport/src/tls.rs
@@ -27,7 +27,9 @@ impl Transport for TlsTransport {
 
     #[cfg(feature = "with_tls")]
     fn send(&self, request: &Request) -> Result<Response, Error> {
-        let connector = native_tls::TlsConnector::new()?;
+        let mut builder = native_tls::TlsConnector::builder();
+        builder.request_alpns(&["dot"]);
+        let connector = builder.build()?;
 
         info!("Opening TLS socket");
         let stream =


### PR DESCRIPTION
Added ALPN support for TLS and HTTPS protocols following the [IANA ALPN list](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#table-alpn-protocol-ids).