### PR TITLE
Fix typos

### DIFF
--- a/dns/src/record/cname.rs
+++ b/dns/src/record/cname.rs
@@ -76,7 +76,7 @@ mod test {
     #[test]
     fn buffer_ends_abruptly() {
         let buf = &[
-            0x05, 0x62, 0x73,  // the stard of a string
+            0x05, 0x62, 0x73,  // the start of a string
         ];
 
         assert_eq!(CNAME::read(23, &mut Cursor::new(buf)),

--- a/dns/src/wire.rs
+++ b/dns/src/wire.rs
@@ -165,7 +165,7 @@ impl Answer {
 
 impl Record {
 
-    /// Reads at most `len` bytes from the given curser, and parses them into
+    /// Reads at most `len` bytes from the given cursor, and parses them into
     /// a record structure depending on the type number, which has already been read.
     #[cfg_attr(feature = "with_mutagen", ::mutagen::mutate)]
     fn from_bytes(record_type: RecordType, len: u16, c: &mut Cursor<&[u8]>) -> Result<Self, WireError> {

--- a/dns/tests/wire_parsing_tests.rs
+++ b/dns/tests/wire_parsing_tests.rs
@@ -157,7 +157,7 @@ fn parse_response_with_mixed_string() {
 #[test]
 fn parse_response_with_multiple_additionals() {
 
-    // This is an artifical amalgam of DNS, not a real-world response!
+    // This is an artificial amalgam of DNS, not a real-world response!
     let buf = &[
         0xce, 0xac,  // transaction ID
         0x81, 0x80,  // flags (standard query, response, no error)

--- a/man/dog.1.md
+++ b/man/dog.1.md
@@ -211,7 +211,7 @@ The `-Z` command-line argument can be used one or more times to set some protoco
 : Sets the `AD` (Authentic Data) bit in the query.
 
 `bufsize=NUM`
-: Sets the UDP payload size field in the OPT field in the query. This has no effect if EDNS is diabled.
+: Sets the UDP payload size field in the OPT field in the query. This has no effect if EDNS is disabled.
 
 `cd`
 : Sets the `CD` (Checking Disabled) bit in the query.

--- a/src/output.rs
+++ b/src/output.rs
@@ -161,7 +161,7 @@ impl OutputFormat {
         true
     }
 
-    /// Print an error that’s ocurred while sending or receiving DNS packets
+    /// Print an error that’s occurred while sending or receiving DNS packets
     /// to standard error.
     pub fn print_error(self, error: TransportError) {
         match self {


### PR DESCRIPTION
Found via `codespell -L crate,additionals,atleast` and `typos --format brief`.