### PR TITLE
Trim nameserver line in resolv.conf before parsing

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -103,7 +103,7 @@ fn system_nameservers() -> Result<Resolver, ResolverLookupError> {
         let line = line?;
 
         if let Some(nameserver_str) = line.strip_prefix("nameserver ") {
-            let ip: Result<std::net::Ipv4Addr, _> = nameserver_str.parse();
+            let ip: Result<std::net::Ipv4Addr, _> = nameserver_str.trim().parse();
             // TODO: This will need to be changed for IPv6 support.
 
             match ip {


### PR DESCRIPTION
Currently, a line like this in `/etc/resolv.conf` will cause the name server to not be picked up:
```
nameserver    1.1.1.1
```

Trimming the string before parsing fixes that.

---

P.s. it is worth discussing whether this is a valid configuration at all. (I.e. is multiple spaces actually allowed?)

So I took a look at [the man page](https://man7.org/linux/man-pages/man5/resolv.conf.5.html), and only found this small paragraph addressing the format:
> The keyword and value must appear on a single line, and the keyword (e.g., nameserver) must start the line.  The value follows the keyword, separated by white space.

Yeah... The description is very ambiguous - it didn't say either "a white space" or "one or more white spaces". On the other hand, `dig` seems to be okay with multiple white spaces, so I think it's best to be defensive and trim first. There's no real downsides so why not.