### PR TITLE
Fix the link to Arch Package fix_arch_repo_link_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To install dog, you can download a pre-compiled binary, or you can compile it fr
 
 ### Packages
 
-- For Arch Linux, install the [`dog`](https://www.archlinux.org/packages/community/x86_64/dog/) package.
+- For Arch Linux, install the [`dog`](https://www.archlinux.org/packages/extra/x86_64/dog/) package.
 - For Homebrew on macOS, install the [`dog`](https://formulae.brew.sh/formula/dog) formula.
 - For NixOS, install the [`dogdns`](https://search.nixos.org/packages?channel=unstable&show=dogdns&query=dogdns) package.
 


### PR DESCRIPTION
This is from the Git Migration moving Community to Extra: https://archlinux.org/news/git-migration-completed/