### PR TITLE
Dockerfile runtime image update to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust as build
+FROM rust AS build
 
 WORKDIR /build
 COPY /src /build/src
@@ -9,9 +9,12 @@ COPY build.rs Cargo.toml /build/
 
 RUN cargo build --release
 
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
-RUN apt update && apt install -y libssl1.1 ca-certificates && apt clean all
+RUN apt update && \
+    apt install -y libssl3 && \
+    apt install -y ca-certificates && \
+    apt clean all
 
 COPY --from=build /build/target/release/dog /dog
 


### PR DESCRIPTION
Update runtime image to debian:bookworm-slim since buster is EOL.  libssl1.1 package replace by libssl3